### PR TITLE
Only update the channel description if the content is changed to prevent spam

### DIFF
--- a/src/staff-list.js
+++ b/src/staff-list.js
@@ -597,8 +597,10 @@ registerPlugin(
                 }
             });
 
-            // set new description to channel
-            channel.setDescription(description);
+            // set new description to channel if the description was modified (to prevent server log spam)
+             if (channel.description() !== description) {
+                channel.setDescription(description);
+            }
         }
 
         // LOADING EVENT


### PR DESCRIPTION
We noticed that the bot is spamming the server log with updates on the channel even though nothing has changed. With this change, the script checks the current description with the updated one and only applies the change if something was changed 