### PR TITLE
reverse group priority

### DIFF
--- a/src/staff-list.js
+++ b/src/staff-list.js
@@ -444,15 +444,17 @@ registerPlugin(
         }
 
         function getStaffGroupFromClient(client, staffGroups) {
-            let group = null;
-            staffGroups.forEach(staffGroup => {
-                if (isStaffClient(client, staffGroup.clients) || hasStaffGroup(client, staffGroup.groups)) {
-                    group = staffGroup;
-                    return;
-                }
-            });
+            log('dude: ' + client.uid());
 
-            return group;
+            for (let staffGroup of staffGroups) {
+                log('check: ' + staffGroup.id);
+                if (isStaffClient(client, staffGroup.clients) || hasStaffGroup(client, staffGroup.groups)) {
+                    log('found: ' + staffGroup.id);
+                    return staffGroup;
+                }
+            }
+
+            return null;
         }
 
         function isStaffClient(client, clients) {

--- a/src/staff-list.js
+++ b/src/staff-list.js
@@ -447,7 +447,7 @@ registerPlugin(
             let group = null;
             staffGroups.forEach(staffGroup => {
                 if (isStaffClient(client, staffGroup.clients) || hasStaffGroup(client, staffGroup.groups))
-                    group = staffGroup;
+                    return staffGroup;
             });
 
             return group;

--- a/src/staff-list.js
+++ b/src/staff-list.js
@@ -444,13 +444,12 @@ registerPlugin(
         }
 
         function getStaffGroupFromClient(client, staffGroups) {
-            let group = null;
             staffGroups.forEach(staffGroup => {
                 if (isStaffClient(client, staffGroup.clients) || hasStaffGroup(client, staffGroup.groups))
                     return staffGroup;
             });
 
-            return group;
+            return null;
         }
 
         function isStaffClient(client, clients) {

--- a/src/staff-list.js
+++ b/src/staff-list.js
@@ -446,9 +446,10 @@ registerPlugin(
         function getStaffGroupFromClient(client, staffGroups) {
             let group = null;
             staffGroups.forEach(staffGroup => {
-                if (isStaffClient(client, staffGroup.clients) || hasStaffGroup(client, staffGroup.groups))
+                if (isStaffClient(client, staffGroup.clients) || hasStaffGroup(client, staffGroup.groups)) {
                     group = staffGroup;
-                return;
+                    return;
+                }
             });
 
             return group;

--- a/src/staff-list.js
+++ b/src/staff-list.js
@@ -280,7 +280,7 @@ registerPlugin(
             {
                 name: 'priority',
                 title:
-                    'The order in which you define the groups is important! The script will go from top to bottom and overwrite each group so the last group you defined has the highest priority. Should a user be a member of two groups, they will only be displayed in the last one.'
+                    'The order in which you define the groups is important! Priority of the groups goes from top to bottom. If a user has two groups, they will be displayed in the group which comes first in the config.'
             },
             {
                 name: 'staffGroups',

--- a/src/staff-list.js
+++ b/src/staff-list.js
@@ -444,12 +444,14 @@ registerPlugin(
         }
 
         function getStaffGroupFromClient(client, staffGroups) {
+            let group = null;
             staffGroups.forEach(staffGroup => {
                 if (isStaffClient(client, staffGroup.clients) || hasStaffGroup(client, staffGroup.groups))
-                    return staffGroup;
+                    group = staffGroup;
+                return;
             });
 
-            return null;
+            return group;
         }
 
         function isStaffClient(client, clients) {


### PR DESCRIPTION

reverses the direction of priority so that the most important groups are the ones first in the config
